### PR TITLE
feat: clean up schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changements
 
+## Version 0.14.0 - 2024-02-26
+
+* schéma structure :
+  * `commune`, `adresse` et `code_postal` deviennent optionnels
+  * `source` devient obligatoire
+  * `antenne` n'est plus défini par défaut
+* schéma service :
+  * `structure_id` devient obligatoire
+
 ## Version 0.13.1 - 2024-01-24
 
 * Ajout de la typologie `FT`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "data-inclusion-schema"
-version = "0.13.1"
+version = "0.14.0"
 description = "Schéma de l'offre d'insertion"
 authors = [{ name = "data.inclusion", email = "data.inclusion@beta.gouv.fr" }]
 readme = "README.md"

--- a/schemas.yml
+++ b/schemas.yml
@@ -1,7 +1,7 @@
 title: Schéma des structures de l'insertion
 description: Schéma des structures de l'insertion
 homepage: https://github.com/betagouv/data-inclusion-schema
-version: 0.13.1
+version: 0.14.0
 
 schemas:
   -

--- a/schemas/services.json
+++ b/schemas/services.json
@@ -75,16 +75,8 @@
           "type": "string"
         },
         "structure_id": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Structure Id"
+          "title": "Structure Id",
+          "type": "string"
         },
         "source": {
           "title": "Source",
@@ -600,6 +592,7 @@
       },
       "required": [
         "id",
+        "structure_id",
         "source",
         "nom"
       ],

--- a/schemas/structures.json
+++ b/schemas/structures.json
@@ -138,15 +138,31 @@
           "type": "string"
         },
         "commune": {
-          "title": "Commune",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Commune"
         },
         "code_postal": {
-          "maxLength": 5,
-          "minLength": 5,
-          "pattern": "^\\d{5}$",
-          "title": "Code Postal",
-          "type": "string"
+          "anyOf": [
+            {
+              "maxLength": 5,
+              "minLength": 5,
+              "pattern": "^\\d{5}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Code Postal"
         },
         "code_insee": {
           "anyOf": [
@@ -164,8 +180,16 @@
           "title": "Code Insee"
         },
         "adresse": {
-          "title": "Adresse",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adresse"
         },
         "complement_adresse": {
           "anyOf": [
@@ -280,16 +304,8 @@
           "title": "Presentation Detail"
         },
         "source": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Source"
+          "title": "Source",
+          "type": "string"
         },
         "date_maj": {
           "anyOf": [
@@ -305,9 +321,16 @@
           "title": "Date Maj"
         },
         "antenne": {
-          "default": false,
-          "title": "Antenne",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Antenne"
         },
         "lien_source": {
           "anyOf": [
@@ -400,9 +423,7 @@
       "required": [
         "id",
         "nom",
-        "commune",
-        "code_postal",
-        "adresse",
+        "source",
         "date_maj"
       ],
       "title": "Structure",

--- a/src/data_inclusion/schema/services.py
+++ b/src/data_inclusion/schema/services.py
@@ -23,7 +23,7 @@ class Service(BaseModel):
 
     # fields
     id: str
-    structure_id: Optional[str] = None
+    structure_id: str
     source: str
     nom: str
     presentation_resume: Optional[

--- a/src/data_inclusion/schema/structures.py
+++ b/src/data_inclusion/schema/structures.py
@@ -19,10 +19,10 @@ class Structure(BaseModel):
     siret: Optional[common.CodeSiret] = None
     rna: Optional[common.CodeRna] = None
     nom: str
-    commune: str
-    code_postal: common.CodePostal
+    commune: Optional[str] = None
+    code_postal: Optional[common.CodePostal] = None
     code_insee: Optional[common.CodeCommune] = None
-    adresse: str
+    adresse: Optional[str] = None
     complement_adresse: Optional[str] = None
     longitude: Optional[float] = None
     latitude: Optional[float] = None
@@ -34,9 +34,9 @@ class Structure(BaseModel):
         Annotated[str, StringConstraints(max_length=280)]
     ] = None
     presentation_detail: Optional[str] = None
-    source: Optional[str] = None
+    source: str
     date_maj: date | datetime
-    antenne: bool = False
+    antenne: Optional[bool] = None
     lien_source: Optional[HttpUrl] = None
     horaires_ouverture: Optional[str] = None
     accessibilite: Optional[HttpUrl] = None


### PR DESCRIPTION
Changements mineurs pour aligner les models pydantic utilisés en prod avec ceux du schéma.

Les champs devenant obligatoires le sont en fait déjà dans la pipeline et l'api.