### PR TITLE
chore: suppression du mode d'orientation `envoyer-un-mail-avec-des-documents-a-completer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Suppressions
 
+* suppression du mode d'orientation accompagnateur `envoyer-un-mail-avec-des-documents-a-completer`
+
 ## 0.16.0 - 2024-06-25
 
 ### Suppressions

--- a/schemas/extra/modes-orientation-accompagnateur.json
+++ b/schemas/extra/modes-orientation-accompagnateur.json
@@ -15,11 +15,6 @@
     "value": "envoyer-un-mail"
   },
   {
-    "description": "Envoyer un courriel à l’adresse indiquée avec des documents à compléter.",
-    "label": "Envoyer un courriel avec des documents à compléter",
-    "value": "envoyer-un-mail-avec-des-documents-a-completer"
-  },
-  {
     "description": "Envoyer un courriel à l’adresse indiquée avec une fiche de prescription.",
     "label": "Envoyer un courriel avec une fiche de prescription",
     "value": "envoyer-un-mail-avec-une-fiche-de-prescription"

--- a/schemas/services.json
+++ b/schemas/services.json
@@ -24,7 +24,6 @@
         "completer-le-formulaire-dadhesion",
         "envoyer-un-mail",
         "envoyer-un-mail-avec-une-fiche-de-prescription",
-        "envoyer-un-mail-avec-des-documents-a-completer",
         "telephoner",
         "prendre-rdv",
         "autre"

--- a/src/data_inclusion/schema/modes_orientation.py
+++ b/src/data_inclusion/schema/modes_orientation.py
@@ -17,11 +17,6 @@ class ModeOrientationAccompagnateur(EnhancedEnum):
         "Envoyer un courriel avec une fiche de prescription",
         "Envoyer un courriel à l’adresse indiquée avec une fiche de prescription.",
     )
-    ENVOYER_UN_MAIL_AVEC_DES_DOCUMENTS_A_COMPLETER = (
-        "envoyer-un-mail-avec-des-documents-a-completer",
-        "Envoyer un courriel avec des documents à compléter",
-        "Envoyer un courriel à l’adresse indiquée avec des documents à compléter.",
-    )
     TELEPHONER = (
         "telephoner",
         "Téléphoner",


### PR DESCRIPTION
Suppression de la "value": "envoyer-un-mail-avec-des-documents-a-completer” des modes orientation accompagnateur. Inutilisée aujourd'hui