### PR TITLE
chore: arrondissage des scores à deux décimales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changements
 
+* arrondissage à deux décimales du score de qualité.
+
 ### Dépréciations
 
 ### Suppressions

--- a/src/data_inclusion/schema/score_qualite.py
+++ b/src/data_inclusion/schema/score_qualite.py
@@ -164,7 +164,9 @@ CRITERES: list[CritereFn] = [
 def score(service: Service) -> tuple[float, Mapping[str, float | None]]:
     resultats = {critere.__name__: critere(service) for critere in CRITERES}
 
-    resultats_pertinents = {k: v for k, v in resultats.items() if v is not None}
+    resultats_pertinents = {
+        k: round(v, 2) for k, v in resultats.items() if v is not None
+    }
     score = sum([v for v in resultats_pertinents.values()]) / len(resultats_pertinents)
 
-    return score, resultats
+    return round(score, 2), resultats

--- a/tests/unit/test_score_qualite.py
+++ b/tests/unit/test_score_qualite.py
@@ -462,7 +462,7 @@ def test_critere_frais_bien_definis(service: Service, attendu: float):
                 thematiques=[Thematique.FAMILLE],
                 profils=[Profil.ADULTES],
             ),
-            (len(score_qualite.CRITERES) - 1) / len(score_qualite.CRITERES),
+            round((len(score_qualite.CRITERES) - 1) / len(score_qualite.CRITERES), 2),
             id="service_presque_parfait_sans_date_maj",
         ),
         pytest.param(


### PR DESCRIPTION
On souhaite éviter les scores du genre `0.91919193` etc. 

`0.91919193` -> `0.92`