### PR TITLE
feat: Add cluster_id in structures

### DIFF
--- a/schemas/structure.json
+++ b/schemas/structure.json
@@ -384,6 +384,18 @@
       "default": null,
       "title": "Antenne"
     },
+    "cluster_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cluster Id"
+    },
     "code_insee": {
       "anyOf": [
         {

--- a/src/data_inclusion/schema/structures.py
+++ b/src/data_inclusion/schema/structures.py
@@ -13,6 +13,7 @@ from data_inclusion.schema.typologies_de_structures import Typologie
 class Structure(BaseModel):
     # fields
     id: str
+    cluster_id: Optional[str] = None
     siret: Optional[common.CodeSiret] = None
     rna: Optional[common.CodeRna] = None
     nom: str


### PR DESCRIPTION
[tout le questionnement est dans le message de commit, que j'avais rédigé en anglais par réflexe]

Not sure if we should add the "duplicates" list in the Structure schema as they will only be present in some, but not all, endpoints and situations.

For instance, it won't be present in the datagouv exports, or as the linked Structure of a service in the service endpoints.

Should we split between a "Structure" and "StructureWithDuplicates" ?