### PR TITLE
chore: documentation du processus de release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,9 +69,18 @@ Ajouter ses modifications au [CHANGELOG](CHANGELOG.md) dans la section "à venir
 
 ## Faire une release
 
+> [!NOTE]
+> Vous devez avoir finalisé au maximum votre proposition avant de lancer une release.
+> PyPI ne permet pas de ré-uploader (ou "forcer") une version déjà uploadée, par sécurité.
+> Chaque nouvelle version demandera un nouveau numéro de package.
+> Voir [la documentation](https://pypi.org/help/#file-name-reuse)
+
 1. Sur une PR:
-    - Modif du numéro de version du package sur [pyproject.toml](pyproject.toml)
-    - Passer les changements de ## À venir dans la section de la nouvelle release
-2. La doc est mise a jour automatiquement depuis le json schema lors d’un merge sur la branch release. Si ajout d’un referentiel de plus de 5 items, il faut ajouter une ligne referencant la page de doc mkdocs.yml
-2. `git tag {my-tag} & git tag -f latest & git push --tags`
-3. release sur git hub en pointant sur le tag
+    - Modifier le numéro de version du package dans [pyproject.toml](pyproject.toml) (pour la release sur PyPI)
+    - Dans le [CHANGELOG](CHANGELOG.md), passer les changements de la section `## À venir` à la section de la nouvelle release
+
+2. La doc est mise à jour automatiquement depuis le json schema lors d’un merge sur la branche release.
+   Si ajout d’un referentiel de plus de 5 items, il faut ajouter une ligne referencant la page de doc mkdocs.yml
+
+3. Mettre à jour le tag Github (pour `schema.data.gouv.fr`) : `git tag {my-tag} & git tag -f latest & git push --tags`
+4. Créer une release sur Github en pointant sur le tag


### PR DESCRIPTION
Amélioration légère de la documentation concernant les releases.

![image](https://github.com/user-attachments/assets/26219c2d-1c5f-4b30-9d69-0234283d7548)


### Check-list

* [x] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
  * `<type>(<optional scope>): <description>`
  * types : `feat`, `chore`, `fix`, `docs`, etc.
  * scopes : `structure`, `service`, `thematiques`, etc.
* [x] Je n'utilise pas l'anglais dans le schéma, la documentation, les commentaires, les messages de commits,
les PRs
  * anglais ok pour le nommage des variables, etc.
* Je respecte les règles de français dans le schéma et la documentation (non dans le code):
  * [x] espace avant les deux-points `:`
  * [x] apostrophe typographique `’` et non `'`
  * [x] accentuation
  * ...
* [x] J'ai exécuté les pre-commits
* NP J'ai mis à jour la section "À venir" du changelog
* NP J'ai mis à jour le schéma json
* NP J'ai mis à jour la documentation du schéma
* NP J'ai indiqué le ticket notion associé
* NP J'ai passé le ticket notion en review
