### PR TITLE
feat(schema): ajouter `date_maj` en requis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Ajouts
 
 ### Changements
+* `date_maj` devient obligatoire
 
 ### Dépréciations
 

--- a/docs/service.md
+++ b/docs/service.md
@@ -611,9 +611,9 @@ Type : `boolean`
 
 ---
 
-### `date_maj`
+### `date_maj` *
 
-
+Date de dernière modification du service chez le producteur de données.
 
 
 
@@ -621,12 +621,19 @@ Type : `string`
 
 
 
-Format : `date | date-time`
+Format : `date`
 
 
 
 
 
+
+Exemples :
+
+```json
+"2025-02-14"
+
+```
 
 ---
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -351,20 +351,27 @@ Type : `string`
 
 ### `date_maj` *
 
+Date de dernière modification de la structure chez le producteur de données.
+
+
+
+Type : `string`
+
+
+
+Format : `date`
 
 
 
 
-Type : ``
 
 
+Exemples :
 
-Format : `date | date-time`
+```json
+"2025-02-14"
 
-
-
-
-
+```
 
 ---
 

--- a/schemas/service.json
+++ b/schemas/service.json
@@ -391,21 +391,13 @@
       "title": "Date Creation"
     },
     "date_maj": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "format": "date-time",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
+      "description": "Date de dernière modification du service chez le producteur de données.",
+      "examples": [
+        "2025-02-14"
       ],
-      "default": null,
-      "title": "Date Maj"
+      "format": "date",
+      "title": "Date de dernière modification",
+      "type": "string"
     },
     "date_suspension": {
       "anyOf": [
@@ -826,7 +818,8 @@
     "id",
     "structure_id",
     "source",
-    "nom"
+    "nom",
+    "date_maj"
   ],
   "title": "Service",
   "type": "object"

--- a/schemas/structure.json
+++ b/schemas/structure.json
@@ -452,17 +452,13 @@
       "title": "Courriel"
     },
     "date_maj": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "format": "date-time",
-          "type": "string"
-        }
+      "description": "Date de dernière modification de la structure chez le producteur de données.",
+      "examples": [
+        "2025-02-14"
       ],
-      "title": "Date Maj"
+      "format": "date",
+      "title": "Date de dernière modification",
+      "type": "string"
     },
     "horaires_ouverture": {
       "anyOf": [

--- a/scripts/compile_docs.py
+++ b/scripts/compile_docs.py
@@ -45,6 +45,11 @@ def snake_case(txt: str) -> str:
 def get_property_type_data(property_schema: dict) -> dict | None:
     match property_schema:
         case {"type": json_type}:
+            if "format" in property_schema:
+                return {
+                    "type": json_type,
+                    "format": property_schema["format"],
+                }
             return {
                 "type": json_type,
             }

--- a/scripts/compile_docs.py
+++ b/scripts/compile_docs.py
@@ -45,14 +45,7 @@ def snake_case(txt: str) -> str:
 def get_property_type_data(property_schema: dict) -> dict | None:
     match property_schema:
         case {"type": json_type}:
-            if "format" in property_schema:
-                return {
-                    "type": json_type,
-                    "format": property_schema["format"],
-                }
-            return {
-                "type": json_type,
-            }
+            return {"type": json_type, "format": property_schema.get("format")}
         case {"anyOf": [{"type": "array", "items": {"$ref": ref}}, {"type": "null"}]}:
             return {
                 "type": "array[string]",

--- a/src/data_inclusion/schema/services.py
+++ b/src/data_inclusion/schema/services.py
@@ -1,4 +1,5 @@
-from datetime import date, datetime
+import textwrap
+from datetime import date
 from typing import Annotated, Optional
 
 from pydantic import EmailStr, HttpUrl, StringConstraints
@@ -52,7 +53,17 @@ class Service(BaseModel):
     telephone: Optional[str] = None
     courriel: Optional[EmailStr] = None
     contact_public: Optional[bool] = None
-    date_maj: Optional[date | datetime] = None
+    date_maj: Annotated[
+        date,
+        Field(
+            description=textwrap.dedent("""\
+                Date de dernière modification du service
+                chez le producteur de données.
+            """),
+            examples=["2025-02-14"],
+            title="Date de dernière modification",
+        ),
+    ]
     modes_accueil: Optional[set[ModeAccueil]] = None
     zone_diffusion_type: Optional[ZoneDiffusionType] = None
     zone_diffusion_code: Optional[

--- a/src/data_inclusion/schema/structures.py
+++ b/src/data_inclusion/schema/structures.py
@@ -1,10 +1,11 @@
-from datetime import date, datetime
+import textwrap
+from datetime import date
 from typing import Annotated, Optional
 
 from pydantic import EmailStr, HttpUrl, StringConstraints
 
 from data_inclusion.schema import common
-from data_inclusion.schema.base import BaseModel
+from data_inclusion.schema.base import BaseModel, Field
 from data_inclusion.schema.labels_nationaux import LabelNational
 from data_inclusion.schema.thematiques import Thematique
 from data_inclusion.schema.typologies_de_structures import TypologieStructure
@@ -32,7 +33,17 @@ class Structure(BaseModel):
     )
     presentation_detail: Optional[str] = None
     source: str
-    date_maj: date | datetime
+    date_maj: Annotated[
+        date,
+        Field(
+            description=textwrap.dedent("""\
+                Date de dernière modification de la
+                structure chez le producteur de données.
+            """),
+            examples=["2025-02-14"],
+            title="Date de dernière modification",
+        ),
+    ]
     antenne: Optional[bool] = None
     lien_source: Optional[HttpUrl] = None
     horaires_ouverture: Optional[str] = None


### PR DESCRIPTION
[Lien vers le ticket notion associé](https://www.notion.so/gip-inclusion/24610bd08f8a412c83c09f6b36a1a44f?v=34cdd4c049e44f49aec060657c72c9b0&p=1a75f321b604807db1bbccc6f98994e3&pm=s)

### Check-list

* [x] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
  * `<type>(<optional scope>): <description>`
  * types : `feat`, `chore`, `fix`, `docs`, etc.
  * scopes : `structure`, `service`, `thematiques`, etc.
* [x] Je n'utilise pas l'anglais dans le schéma, la documentation, les commentaires, les messages de commits,
les PRs
  * anglais ok pour le nommage des variables, etc.
* Je respecte les règles de français dans le schéma et la documentation (non dans le code):
  * [x] espace avant les deux-points `:`
  * [x] apostrophe typographique `’` et non `'`
  * [x] accentuation
  * ...
* [x] J'ai exécuté les pre-commits
* [x] J'ai mis à jour la section "À venir" du changelog
* [x] J'ai mis à jour le schéma json
* [x] J'ai mis à jour la documentation du schéma
* [x] J'ai indiqué le ticket notion associé
* [x] J'ai passé le ticket notion en review
