### PR TITLE
feat: ajout de la description des champs "courriel" v0 & v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Ajouts
 
 ### Changements
+* documentation des champs courriel (Service & Structures)
 
 ### Dépréciations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@
 ### Ajouts
 
 ### Changements
-* documentation des champs courriel (Service & Structures)
 
 ### Dépréciations
 
 ### Suppressions
+
+## 0.24.0 - 2025-04-17
+
+### Changements
+
+* ajout de description sur les champs `courriel`
+* modifications typographiques
 
 ## 0.23.0 - 2025-04-15
 

--- a/docs/model.md.j2
+++ b/docs/model.md.j2
@@ -1,4 +1,4 @@
-!!! info "Les champs marqués d'une astérisque (*) sont obligatoires."
+!!! info "Les champs marqués d’une astérisque (*) sont obligatoires."
 
 {% for property_name, property_schema in schema.properties.items() %}
 

--- a/docs/service.md
+++ b/docs/service.md
@@ -1,4 +1,4 @@
-!!! info "Les champs marqués d'une astérisque (*) sont obligatoires."
+!!! info "Les champs marqués d’une astérisque (*) sont obligatoires."
 
 
 

--- a/docs/service.md
+++ b/docs/service.md
@@ -593,7 +593,11 @@ Exemples :
 
 ### `courriel`
 
+Courriel à utiliser pour obtenir des informations complémentaires sur le service. Si le mode de mobilisation est `envoyer-un-email`, peut être utilisé pour mobiliser le service.
 
+Doit suivre le format de la RFC 5322. Vérification de l’existence du destinataire (envoi d’un courrier de notification)
+
+Si non conforme ou destinataire inexistant, suppression de la valeur.
 
 
 
@@ -607,6 +611,13 @@ Format : `email`
 
 
 
+
+Exemples :
+
+```json
+"exemple@inclusion.gouv.fr"
+
+```
 
 ---
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -274,7 +274,9 @@ Exemples :
 
 ### `courriel`
 
+Courriel à utiliser pour obtenir des informations complémentaires sur la structure.
 
+Doit suivre le format de la RFC 5322.
 
 
 
@@ -288,6 +290,13 @@ Format : `email`
 
 
 
+
+Exemples :
+
+```json
+"exemple@inclusion.gouv.fr"
+
+```
 
 ---
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,4 +1,4 @@
-!!! info "Les champs marqués d'une astérisque (*) sont obligatoires."
+!!! info "Les champs marqués d’une astérisque (*) sont obligatoires."
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 requires-python = ">=3.10"
 name = "data-inclusion-schema"
-version = "0.23.0"
+version = "0.24.0"
 description = "Schéma de l'offre d'insertion"
 authors = [{ name = "data⋅inclusion", email = "data-inclusion@inclusion.gouv.fr" }]
 readme = "README.md"

--- a/schemas.yml
+++ b/schemas.yml
@@ -1,8 +1,8 @@
-title: Services de l'inclusion
-description: Services de l'inclusion
+title: Services de l’inclusion
+description: Services de l’inclusion
 homepage: https://github.com/gip-inclusion/data-inclusion-schema
 
 schemas:
   -
     path: "schemas/service.json"
-    title: "Services de l'inclusion"
+    title: "Services de l’inclusion"

--- a/schemas/service.json
+++ b/schemas/service.json
@@ -363,6 +363,10 @@
         }
       ],
       "default": null,
+      "description": "Courriel à utiliser pour obtenir des informations complémentaires sur le service. Si le mode de mobilisation est `envoyer-un-email`, peut être utilisé pour mobiliser le service.\n\nDoit suivre le format de la RFC 5322. Vérification de l’existence du destinataire (envoi d’un courrier de notification)\n\nSi non conforme ou destinataire inexistant, suppression de la valeur.",
+      "examples": [
+        "exemple@inclusion.gouv.fr"
+      ],
       "title": "Courriel"
     },
     "cumulable": {

--- a/schemas/structure.json
+++ b/schemas/structure.json
@@ -449,6 +449,10 @@
         }
       ],
       "default": null,
+      "description": "Courriel à utiliser pour obtenir des informations complémentaires sur la structure.\n\nDoit suivre le format de la RFC 5322.",
+      "examples": [
+        "exemple@inclusion.gouv.fr"
+      ],
       "title": "Courriel"
     },
     "date_maj": {

--- a/src/data_inclusion/schema/services.py
+++ b/src/data_inclusion/schema/services.py
@@ -76,7 +76,24 @@ class Service(BaseModel):
             title="Téléphone",
         ),
     ]
-    courriel: Optional[EmailStr] = None
+    courriel: Annotated[
+        Optional[EmailStr],
+        Field(
+            description="""
+                Courriel à utiliser pour obtenir des informations complémentaires sur
+                le service. Si le mode de mobilisation est `envoyer-un-email`, peut
+                être utilisé pour mobiliser le service.
+
+                Doit suivre le format de la RFC 5322.
+                Vérification de l’existence du destinataire (envoi d’un courrier
+                de notification)
+
+                Si non conforme ou destinataire inexistant, suppression de la valeur.
+            """,
+            examples=["exemple@inclusion.gouv.fr"],
+            default=None,
+        ),
+    ]
     contact_public: Optional[bool] = None
     date_maj: Annotated[
         date,

--- a/src/data_inclusion/schema/structures.py
+++ b/src/data_inclusion/schema/structures.py
@@ -52,7 +52,19 @@ class Structure(BaseModel):
             title="Téléphone",
         ),
     ]
-    courriel: Optional[EmailStr] = None
+    courriel: Annotated[
+        Optional[EmailStr],
+        Field(
+            description="""
+                Courriel à utiliser pour obtenir des informations complémentaires sur
+                la structure.
+
+                Doit suivre le format de la RFC 5322.
+            """,
+            default=None,
+            examples=["exemple@inclusion.gouv.fr"],
+        ),
+    ]
     site_web: Optional[HttpUrl] = None
     presentation_resume: Annotated[Optional[str], Field(max_length=280)] = None
     presentation_detail: Optional[str] = None

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.10"
 
 [[package]]
@@ -122,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "data-inclusion-schema"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "pendulum" },


### PR DESCRIPTION
[Lien vers le ticket notion associé](https://www.notion.so/gip-inclusion/Champs-courriel-1a75f321b60480b09244e754b783237d?pvs=4)

### Check-list

* [x] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
  * `<type>(<optional scope>): <description>`
  * types : `feat`, `chore`, `fix`, `docs`, etc.
  * scopes : `structure`, `service`, `thematiques`, etc.
* [x] Je n'utilise pas l'anglais dans le schéma, la documentation, les commentaires, les messages de commits,
les PRs
  * anglais ok pour le nommage des variables, etc.
* Je respecte les règles de français dans le schéma et la documentation (non dans le code):
  * [x] espace avant les deux-points `:`
  * [x] apostrophe typographique `’` et non `'`
  * [x] accentuation
  * ...
* [x] J'ai exécuté les pre-commits
* [x] J'ai mis à jour la section "À venir" du changelog
* [x] J'ai mis à jour le schéma json
* [x] J'ai mis à jour la documentation du schéma
* [x] J'ai indiqué le ticket notion associé
* [x] J'ai passé le ticket notion en review
