### PR TITLE
feat!: remplacement `presentation_***` par `description`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,13 @@
 repos:
+- repo: local
+  hooks:
+    - id: pytest
+      name: pytest
+      language: system
+      entry: pytest
+      always_run: true
+      pass_filenames: false
+      fail_fast: true
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.9.6
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Ajout des champs volume_horaire_hebdomadaire et nombre_semaines
 
 ## 1.0.0 - 2025-XX-XX
 
+### Changements
+
+* remplacement des champs `presentation_***` en faveur d'un champ unique `description` et mise à jour du critère de qualité `description_bien_definie`
+
 ### Suppressions
 
 **Schéma structure**

--- a/docs/service.md
+++ b/docs/service.md
@@ -87,28 +87,13 @@ Exemples :
 
 ---
 
-### `presentation_resume`
+### `description` *
 
+Description du service.
 
+Entre 50 et 2000 caractères.
 
-
-
-Type : `string`
-
-
-
-
-
-
-
-
-
-
----
-
-### `presentation_detail`
-
-
+Ce champ est pris en compte dans le calcul du score de qualité.
 
 
 
@@ -122,6 +107,13 @@ Type : `string`
 
 
 
+
+Exemples :
+
+```json
+"Cet atelier-conseil vous permet d\u2019identifier les comp\u00e9tences \u00e0\n                d\u00e9velopper pour atteindre vos objectifs d\u2019\u00e9volution professionnelle et \u00e0\n                d\u00e9couvrir les diff\u00e9rentes modalit\u00e9s de formation.\n\n                Dur\u00e9e d\u2019une journ\u00e9e et inscription via votre espace France Travail."
+
+```
 
 ---
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -300,28 +300,11 @@ Format : `uri`
 
 ---
 
-### `presentation_resume`
+### `description` *
 
+Description de la structure.
 
-
-
-
-Type : `string`
-
-
-
-
-
-
-
-
-
-
----
-
-### `presentation_detail`
-
-
+Entre 50 et 2000 caractères.
 
 
 
@@ -335,6 +318,13 @@ Type : `string`
 
 
 
+
+Exemples :
+
+```json
+"L\u2019association 3027 offre un acc\u00e8s gratuit aux arts, \u00e0 la culture et\n                au sport pour toutes et tous sans distinction et en priorit\u00e9 aux\n                personnes en situation de pr\u00e9carit\u00e9 et d\u2019isolement."
+
+```
 
 ---
 

--- a/schemas/v1/service.json
+++ b/schemas/v1/service.json
@@ -366,6 +366,16 @@
       "title": "Date de dernière modification",
       "type": "string"
     },
+    "description": {
+      "description": "Description du service.\n\nEntre 50 et 2000 caractères.\n\nCe champ est pris en compte dans le calcul du score de qualité.",
+      "examples": [
+        "Cet atelier-conseil vous permet d’identifier les compétences à\n                développer pour atteindre vos objectifs d’évolution professionnelle et à\n                découvrir les différentes modalités de formation.\n\n                Durée d’une journée et inscription via votre espace France Travail."
+      ],
+      "maxLength": 2000,
+      "minLength": 50,
+      "title": "Description",
+      "type": "string"
+    },
     "formulaire_en_ligne": {
       "anyOf": [
         {
@@ -587,31 +597,6 @@
       "default": null,
       "title": "Pre Requis"
     },
-    "presentation_detail": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Presentation Detail"
-    },
-    "presentation_resume": {
-      "anyOf": [
-        {
-          "maxLength": 280,
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Presentation Resume"
-    },
     "prise_rdv": {
       "anyOf": [
         {
@@ -790,6 +775,7 @@
     "structure_id",
     "source",
     "nom",
+    "description",
     "date_maj"
   ],
   "title": "Service",

--- a/schemas/v1/structure.json
+++ b/schemas/v1/structure.json
@@ -297,6 +297,16 @@
       "title": "Date de dernière modification",
       "type": "string"
     },
+    "description": {
+      "description": "Description de la structure.\n\nEntre 50 et 2000 caractères.",
+      "examples": [
+        "L’association 3027 offre un accès gratuit aux arts, à la culture et\n                au sport pour toutes et tous sans distinction et en priorité aux\n                personnes en situation de précarité et d’isolement."
+      ],
+      "maxLength": 2000,
+      "minLength": 50,
+      "title": "Description",
+      "type": "string"
+    },
     "horaires_ouverture": {
       "anyOf": [
         {
@@ -379,31 +389,6 @@
       "title": "Nom",
       "type": "string"
     },
-    "presentation_detail": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Presentation Detail"
-    },
-    "presentation_resume": {
-      "anyOf": [
-        {
-          "maxLength": 280,
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Presentation Resume"
-    },
     "siret": {
       "anyOf": [
         {
@@ -469,6 +454,7 @@
   "required": [
     "id",
     "nom",
+    "description",
     "source",
     "date_maj"
   ],

--- a/src/data_inclusion/schema/v1/score_qualite.py
+++ b/src/data_inclusion/schema/v1/score_qualite.py
@@ -2,7 +2,7 @@ from typing import Callable, Mapping
 
 import pendulum
 
-from data_inclusion.schema.v0 import (
+from data_inclusion.schema.v1 import (
     Frais,
     ModeAccueil,
     ModeOrientationAccompagnateur,
@@ -122,19 +122,11 @@ def description_bien_definie(service: Service) -> float:
     SEUIL_MINIMUM = 200
     SEUIL_BON = 400
 
-    longueur_presentation = 0
-
-    if service.presentation_resume:
-        longueur_presentation = len(service.presentation_resume)
-
-    if service.presentation_detail:
-        longueur_presentation += len(service.presentation_detail)
-
-    if longueur_presentation < SEUIL_MINIMUM:
+    if len(service.description) < SEUIL_MINIMUM:
         return 0.0
-    elif longueur_presentation < SEUIL_BON:
+    elif len(service.description) < SEUIL_BON:
         # simple interpolation linéaire entre 0 et 1
-        return (longueur_presentation - SEUIL_MINIMUM) / (SEUIL_BON - SEUIL_MINIMUM)
+        return (len(service.description) - SEUIL_MINIMUM) / (SEUIL_BON - SEUIL_MINIMUM)
     else:
         return 1.0
 

--- a/src/data_inclusion/schema/v1/services.py
+++ b/src/data_inclusion/schema/v1/services.py
@@ -36,8 +36,27 @@ class Service(BaseModel):
             max_length=150,
         ),
     ]
-    presentation_resume: Annotated[Optional[str], Field(max_length=280)] = None
-    presentation_detail: Optional[str] = None
+    description: Annotated[
+        str,
+        Field(
+            description="""
+                Description du service.
+
+                Entre 50 et 2000 caractères.
+
+                Ce champ est pris en compte dans le calcul du score de qualité.
+            """,
+            examples=[
+                """Cet atelier-conseil vous permet d’identifier les compétences à
+                développer pour atteindre vos objectifs d’évolution professionnelle et à
+                découvrir les différentes modalités de formation.
+
+                Durée d’une journée et inscription via votre espace France Travail."""
+            ],
+            min_length=50,
+            max_length=2000,
+        ),
+    ]
     types: Optional[set[TypologieService]] = None
     thematiques: Optional[set[Thematique]] = None
     prise_rdv: Optional[HttpUrl] = None

--- a/src/data_inclusion/schema/v1/structures.py
+++ b/src/data_inclusion/schema/v1/structures.py
@@ -63,8 +63,23 @@ class Structure(BaseModel):
         ),
     ]
     site_web: Optional[HttpUrl] = None
-    presentation_resume: Annotated[Optional[str], Field(max_length=280)] = None
-    presentation_detail: Optional[str] = None
+    description: Annotated[
+        str,
+        Field(
+            description="""
+                Description de la structure.
+
+                Entre 50 et 2000 caractères.
+            """,
+            examples=[
+                """L’association 3027 offre un accès gratuit aux arts, à la culture et
+                au sport pour toutes et tous sans distinction et en priorité aux
+                personnes en situation de précarité et d’isolement."""
+            ],
+            min_length=50,
+            max_length=2000,
+        ),
+    ]
     source: str
     date_maj: Annotated[
         date,

--- a/tests/unit/v1/test_score_qualite.py
+++ b/tests/unit/v1/test_score_qualite.py
@@ -23,6 +23,7 @@ def service_factory(**kwargs):
         "nom": "foo",
         "date_maj": pendulum.today(),
         "source": "3",
+        "description": "." * 500,
     }
     kwargs = defaults | kwargs
     return Service(**kwargs)
@@ -386,36 +387,19 @@ def test_critere_au_moins_un_moyen_de_contact(service: Service, attendu: float):
     ("service", "attendu"),
     [
         pytest.param(
-            service_factory(
-                presentation_resume=None,
-                presentation_detail=None,
-            ),
-            0.0,
-            id="aucune_presentation",
-        ),
-        pytest.param(
-            service_factory(
-                presentation_resume="." * 200,
-                presentation_detail=None,
-            ),
+            service_factory(description="." * 100),
             0.0,
             id="description_bien_trop_courte",
         ),
         pytest.param(
-            service_factory(
-                presentation_resume="." * 100,
-                presentation_detail="." * 200,
-            ),
+            service_factory(description="." * 300),
             0.5,
-            id="presentation_assez_courte",
+            id="description_assez_courte",
         ),
         pytest.param(
-            service_factory(
-                presentation_resume=None,
-                presentation_detail="." * 400,
-            ),
+            service_factory(description="." * 400),
             1.0,
-            id="presentation_longue",
+            id="description_longue",
         ),
     ],
 )
@@ -478,7 +462,7 @@ def test_critere_frais_bien_definis(service: Service, attendu: float):
                 profils=[Profil.ADULTES],
                 telephone="3615",
                 modes_orientation_beneficiaire=[ModeOrientationBeneficiaire.TELEPHONER],
-                presentation_detail="longue présentation" * 100,
+                description="." * 500,
             ),
             1.0,
             id="service_parfait",
@@ -490,7 +474,7 @@ def test_critere_frais_bien_definis(service: Service, attendu: float):
                 courriel="lorem@ipsum.dolor",
                 frais=[Frais.PAYANT],
                 frais_autres="lorem ipsum",
-                presentation_detail="longue présentation" * 100,
+                description="." * 500,
                 modes_accueil=[ModeAccueil.EN_PRESENTIEL],
                 modes_orientation_beneficiaire=[ModeOrientationBeneficiaire.TELEPHONER],
                 modes_orientation_accompagnateur=[
@@ -506,6 +490,7 @@ def test_critere_frais_bien_definis(service: Service, attendu: float):
         pytest.param(
             service_factory(
                 date_maj=pendulum.today() - pendulum.Duration(years=3),
+                description="." * 50,
             ),
             0.0,
             id="service_faisandé",


### PR DESCRIPTION
[Lien vers le ticket notion associé](https://www.notion.so/gip-inclusion/Champs-description-1f95f321b6048038bbb5dbd270b6ad71)

### Check-list

* [x] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
  * `<type>(<optional scope>): <description>`
  * types : `feat`, `chore`, `fix`, `docs`, etc.
  * scopes : `structure`, `service`, `thematiques`, etc.
* [x] Je n'utilise pas l'anglais dans le schéma, la documentation, les commentaires, les messages de commits,
les PRs
  * anglais ok pour le nommage des variables, etc.
* Je respecte les règles de français dans le schéma et la documentation (non dans le code):
  * [x] espace avant les deux-points `:`
  * [x] apostrophe typographique `’` et non `'`
  * [ ] accentuation
  * ...
* [x] J'ai exécuté les pre-commits
* [x] J'ai mis à jour la section "À venir" du changelog
* [x] J'ai mis à jour le schéma json
* [x] J'ai mis à jour la documentation du schéma
* [x] J'ai indiqué le ticket notion associé
* [ ] J'ai passé le ticket notion en review
